### PR TITLE
[WIP] Support Ruby 3.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM rubylang/ruby:3.0.0-focal
 
 Add . /opt/chitanda-san
 WORKDIR /opt/chitanda-san

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM rubylang/ruby:3.0.0-focal
 Add . /opt/chitanda-san
 WORKDIR /opt/chitanda-san
 
-RUN gem install bundler \
- && bundle install --deployment --without development -j4
+RUN gem install bundler\
+ && bundle config set deployment 'true'\
+ && bundle config set without 'development'\
+ && bundle install -j4
 
 CMD bundle exec ruby bin/chitanda-san.rb

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM rubylang/ruby:3.0.0-focal
 Add . /opt/chitanda-san
 WORKDIR /opt/chitanda-san
 
-RUN gem install bundler\
- && bundle config set deployment 'true'\
+RUN bundle config set deployment 'true'\
  && bundle config set without 'development'\
  && bundle install -j4
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'faraday_middleware'
 gem 'multi_xml'
 gem 'slack-notifier'
 gem 'dotenv'
+gem 'rexml'
 
 group :development do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     rake (13.0.3)
+    rexml (3.2.4)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -58,6 +59,7 @@ DEPENDENCIES
   multi_xml
   pry
   rake
+  rexml
   rspec
   slack-notifier
 


### PR DESCRIPTION
Add some fixes to support Ruby 3.0.0.

- Add `rexml` to dependency.
- Update Docker base image.
- Migrate deprecated bundler options.